### PR TITLE
Add dockerfile support building for different architectures

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,6 +2,9 @@
 ARG GO_VERSION=1.22
 FROM golang:${GO_VERSION}-alpine AS builder
 
+ARG TARGETOS
+ARG TARGETARCH
+
 WORKDIR /app
 
 # Copy Go modules and download dependencies first
@@ -15,7 +18,7 @@ COPY . .
 # Build the static binary for the command-line tool
 # CGO_ENABLED=0 produces a static binary, important for distroless/scratch images
 # -ldflags="-s -w" strips debug symbols and DWARF info, reducing binary size
-RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -ldflags="-s -w" -o /openapi-mcp ./cmd/openapi-mcp/main.go
+RUN CGO_ENABLED=0 GOOS=$TARGETOS GOARCH=$TARGETARCH go build -ldflags="-s -w" -o /openapi-mcp ./cmd/openapi-mcp/main.go
 
 # --- Final Stage ---
 # Use a minimal base image. distroless/static is very small and secure.


### PR DESCRIPTION
I could not pull and run your image on my apple silicon mac. The changes introduced allowed me to build a local image and run it, too.

I am not a dockerfile expoert, but the thing looks sensible to me. Please check that it also still works for you, then I'd think that it is an improvement.