### PR TITLE
Fix logging/setLevel request not handled

### DIFF
--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -433,6 +433,8 @@ func httpMethodPostHandler(w http.ResponseWriter, r *http.Request, toolSet *mcp.
 			w.WriteHeader(http.StatusAccepted)
 			fmt.Fprintln(w, "Notification received.")
 			return // Return early, do not send anything on SSE channel
+		case "logging/setLevel":
+			respToSend = handleLoggingSetLevelJSONRPC(connID, &req)
 		case "tools/list":
 			respToSend = handleToolsListJSONRPC(connID, &req, toolSet)
 		case "tools/call":
@@ -516,6 +518,16 @@ func handleToolsListJSONRPC(connID string, req *jsonRPCRequest, toolSet *mcp.Too
 		Jsonrpc: "2.0",
 		ID:      req.ID, // Match request ID
 		Result:  resultPayload,
+	}
+}
+
+func handleLoggingSetLevelJSONRPC(connID string, req *jsonRPCRequest) jsonRPCResponse {
+	log.Printf("Handling 'logging/setLevel' (JSON-RPC) for %s", connID)
+
+	return jsonRPCResponse{
+		Jsonrpc: "2.0",
+		ID:      req.ID,
+		Result:  map[string]interface{}{},
 	}
 }
 

--- a/pkg/server/server_test.go
+++ b/pkg/server/server_test.go
@@ -149,6 +149,26 @@ func TestHttpMethodPostHandler(t *testing.T) {
 			},
 		},
 		{
+			name: "Valid Logging Set Level Request",
+			requestBodyFn: func(connID string) string {
+				return `{
+					"jsonrpc": "2.0",
+					"method": "logging/setLevel",
+					"id": "logging-post-1",
+					"params": {"level": "info"}
+				}`
+			},
+			expectedSyncStatus: http.StatusAccepted,
+			expectedSyncBody:   "Request accepted, response will be sent via SSE.\n",
+			checkAsyncResponse: func(t *testing.T, resp jsonRPCResponse) {
+				assert.Equal(t, "logging-post-1", resp.ID)
+				assert.Nil(t, resp.Error)
+				resultMap, ok := resp.Result.(map[string]interface{})
+				require.True(t, ok)
+				assert.Empty(t, resultMap)
+			},
+		},
+		{
 			name: "Valid Tool Call Request (Success)",
 			requestBodyFn: func(connID string) string {
 				return `{


### PR DESCRIPTION
Connect the endpoint on MCP Inspector: `Server declares logging capability but doesn't implement method: "logging/setLevel"`


temp docker image: https://hub.docker.com/r/kiuber/openapi-mcp